### PR TITLE
Put our middleware above security

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ This package is not an alternative to something like [django-health-check](https
 
 ## How it works
 
-This package works by returning an HTTP response from a middleware class before Django's common middleware performs the host check. The Django URL routing system is also bypassed since that happens "below" all middleware. During request processing, *django-lb-health-check* checks if the request is a *GET* request and matches `settings.ALIVENESS_URL`. If it is, a static plain text "200 OK" response is returned bypassing any other processing.
+This package works by returning an HTTP response from a middleware class before Django's common middleware performs the host check and before the security middleware does HTTPS checks. The Django URL routing system is also bypassed since that happens "below" all middleware. During request processing, *django-lb-health-check* checks if the request is a *GET* request and matches `settings.ALIVENESS_URL`. If it is, a static plain text "200 OK" response is returned bypassing any other processing.
 
 
 ## Usage
@@ -21,12 +21,12 @@ Install *django-lb-health-check*
 pip install django-lb-health-check
 ```
 
-Add *lb_health_check* to your middleware. It **must** be above *django.middleware.common.CommonMiddleware* and should be below *django.middleware.security.SecurityMiddleware*, as high in the stack as possible to prevent any queries or unneeded code from running during a health check.
+Add *lb_health_check* to your middleware at the top position. It **must** be above *django.middleware.common.CommonMiddleware* and in most cases should be above *django.middleware.security.SecurityMiddleware*. Security middleware does things like check for HTTPS, which is often missing in health checks from load balancers. Common middleware does the checks against ALLOWED_HOSTS.
 
 ```python
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
     'lb_health_check.middleware.AliveCheck', #  <- New middleware here
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/Readme.md
+++ b/Readme.md
@@ -49,4 +49,4 @@ curl localhost:8000/health-check/
 OK
 ```
 
-Note that the example app has *lb_health_check* in INSTALLED_APPS. This is only nessecary for testing purposes - the app does not use any Django models, admin, views, URL routing, or the like that would require it to be listed in INSTALLED_APPS.
+Note that the example app has *lb_health_check* in INSTALLED_APPS. This is only necessary for testing purposes - the app does not use any Django models, admin, views, URL routing, or the like that would require it to be listed in INSTALLED_APPS.

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -34,11 +34,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-
-    # AliveCheck needs to be as high as possible below SecurityMiddlware
-    # and absolutely above CommonMiddleware.
+    # AliveCheck generally needs to be the top middleware
     'lb_health_check.middleware.AliveCheck',
+    'django.middleware.security.SecurityMiddleware',
 
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/lb_health_check/middleware.py
+++ b/lb_health_check/middleware.py
@@ -8,10 +8,11 @@ from django.http import HttpResponse
 
 log = logging.getLogger(__name__)
 
-COMMON_MIDDLWARE = "django.middleware.common.CommonMiddleware"
+COMMON_MIDDLEWARE = "django.middleware.common.CommonMiddleware"
+SECURITY_MIDDLEWARE = "django.middleware.security.SecurityMiddleware"
 
 # Middleware that the AliveCheck must come before
-MUST_ABOVE = [COMMON_MIDDLWARE]
+MUST_ABOVE = [COMMON_MIDDLEWARE, SECURITY_MIDDLEWARE]
 
 
 class AliveCheck:
@@ -21,7 +22,7 @@ class AliveCheck:
     def __init__(self, get_response):
         self.get_response = get_response
 
-        # I onlt want to warn and not disable because it's possible to do some trickery
+        # I only want to warn and not disable because it's possible to do some trickery
         # in the ALLOWED_HOSTS or common middleware to still respond properly
         _check_middleware_position()
 
@@ -107,7 +108,7 @@ def _check_middleware_position():
 
         if pos < my_position:
             log.warning(
-                "%s is before %s in middlware. "
+                "%s is before %s in middleware. "
                 "Aliveness check may not work properly",
                 name,
                 AliveCheck.get_import_name(),

--- a/lb_health_check/tests.py
+++ b/lb_health_check/tests.py
@@ -113,7 +113,7 @@ class AlivenessURLTestCase(TestCase):
             "WARNING:lb_health_check.middleware:django.middleware.common.CommonMiddleware is before lb_health_check.middleware.AliveCheck in middleware. Aliveness check may not work properly",
             cm.output,
         )
-    
+
     @override_settings(MIDDLEWARE=[SECURITY_MIDDLEWARE, AliveCheck.get_import_name()])
     def test_wrong_order_security(self):
         with self.assertLogs(logger="lb_health_check.middleware", level="DEBUG") as cm:

--- a/lb_health_check/tests.py
+++ b/lb_health_check/tests.py
@@ -1,7 +1,7 @@
 from django.test import TestCase, override_settings
 from django.conf import settings
 
-from .middleware import AliveCheck, COMMON_MIDDLWARE
+from .middleware import SECURITY_MIDDLEWARE, AliveCheck, COMMON_MIDDLEWARE
 
 
 class AlivenessURLTestCase(TestCase):
@@ -92,7 +92,7 @@ class AlivenessURLTestCase(TestCase):
             cm.output,
         )
 
-    @override_settings(MIDDLEWARE=[COMMON_MIDDLWARE])
+    @override_settings(MIDDLEWARE=[COMMON_MIDDLEWARE])
     def test_missing_aliveness_middleware_with_common(self):
         with self.assertLogs(logger="lb_health_check.middleware", level="DEBUG") as cm:
             # We have to construct the alivenss check manually to trigger this
@@ -103,13 +103,24 @@ class AlivenessURLTestCase(TestCase):
             cm.output,
         )
 
-    @override_settings(MIDDLEWARE=[COMMON_MIDDLWARE, AliveCheck.get_import_name()])
+    @override_settings(MIDDLEWARE=[COMMON_MIDDLEWARE, AliveCheck.get_import_name()])
     def test_wrong_order(self):
         with self.assertLogs(logger="lb_health_check.middleware", level="DEBUG") as cm:
             # This will trigger middleware instantiation and such
             self.client.get("/health-check/")
 
         self.assertIn(
-            "WARNING:lb_health_check.middleware:django.middleware.common.CommonMiddleware is before lb_health_check.middleware.AliveCheck in middlware. Aliveness check may not work properly",
+            "WARNING:lb_health_check.middleware:django.middleware.common.CommonMiddleware is before lb_health_check.middleware.AliveCheck in middleware. Aliveness check may not work properly",
+            cm.output,
+        )
+    
+    @override_settings(MIDDLEWARE=[SECURITY_MIDDLEWARE, AliveCheck.get_import_name()])
+    def test_wrong_order_security(self):
+        with self.assertLogs(logger="lb_health_check.middleware", level="DEBUG") as cm:
+            # This will trigger middleware instantiation and such
+            self.client.get("/health-check/")
+
+        self.assertIn(
+            "WARNING:lb_health_check.middleware:django.middleware.security.SecurityMiddleware is before lb_health_check.middleware.AliveCheck in middleware. Aliveness check may not work properly",
             cm.output,
         )


### PR DESCRIPTION
Some of the security checks are for HTTPS, which is often not the case for load balancer checks. Change recommendations and checks to put our middleware above the security middleware for this reason.