### PR TITLE
Use explicit test versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,23 +9,59 @@ jobs:
       POETRY_VIRTUALENVS_CREATE: false
     strategy:
       matrix:
-        python-version:
-          - "3.6"
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
-        django-version:
-          - 2.2.*
-          - 3.0.*
-          - 3.1.*
-          - 3.2.*
+        versions:
+          # Django 2.2
+          - django: "2.2.*"
+            python: "3.7"
+          - django: "2.2.*"
+            python: "3.8"
+          - django: "2.2.*"
+            python: "3.9"
+          # Django 3.0
+          - django: "3.0.*"
+            python: "3.7"
+          - django: "3.0.*"
+            python: "3.8"
+          - django: "3.0.*"
+            python: "3.9"
+          # Django 3.1
+          - django: "3.1.*"
+            python: "3.7"
+          - django: "3.1.*"
+            python: "3.8"
+          - django: "3.1.*"
+            python: "3.9"
+          # Django 3.2
+          - django: "3.2.*"
+            python: "3.7"
+          - django: "3.2.*"
+            python: "3.8"
+          - django: "3.2.*"
+            python: "3.9"
+          - django: "3.2.*"
+            python: "3.10"
+          # Django 4.0
+          - django: "4.0.*"
+            python: "3.8"
+          - django: "4.0.*"
+            python: "3.9"
+          - django: "4.0.*"
+            python: "3.10"
+          # Django 4.1
+          - django: "4.1.*"
+            python: "3.8"
+          - django: "4.1.*"
+            python: "3.9"
+          - django: "4.1.*"
+            python: "3.10"
+          - django: "4.1.*"
+            python: "3.11"
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python version ${{ matrix.python-version }}
+      - name: Setup Python version ${{ matrix.versions.python }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.versions.python }}
       - name: Install poetry
         run: |
           python -m ensurepip
@@ -35,7 +71,7 @@ jobs:
       - name: Set up dependencies
         run: python -m poetry install
       - name: Re-install specific Django version
-        run: pip install Django=="${{ matrix.django-version }}"
+        run: pip install Django=="${{ matrix.versions.django }}"
       - name: Run tests
         run: python example/manage.py test
   

--- a/Readme.md
+++ b/Readme.md
@@ -50,3 +50,43 @@ OK
 ```
 
 Note that the example app has *lb_health_check* in INSTALLED_APPS. This is only necessary for testing purposes - the app does not use any Django models, admin, views, URL routing, or the like that would require it to be listed in INSTALLED_APPS.
+
+## Tested versions
+
+### Django 2.2
+
+- Python 3.7
+- Python 3.8
+- Python 3.9
+
+### Django 3.0
+
+- Python 3.7
+- Python 3.8
+- Python 3.9
+
+### Django 3.1
+
+- Python 3.7
+- Python 3.8
+- Python 3.9
+
+### Django 3.2
+
+- Python 3.7
+- Python 3.8
+- Python 3.9
+- Python 3.10
+
+### Django 4.0
+
+- Python 3.8
+- Python 3.9
+- Python 3.10
+
+### Django 4.1
+
+- Python 3.8
+- Python 3.9
+- Python 3.10
+- Python 3.11


### PR DESCRIPTION
- Update tests to go up to Django 4.1
- Use an explicit strategy for supported Python/Django permutations instead of having to do a bunch of exclusions